### PR TITLE
Add request error trait

### DIFF
--- a/src/LangleyFoxall/Helpers/Traits/ReturnRequestFirstError.php
+++ b/src/LangleyFoxall/Helpers/Traits/ReturnRequestFirstError.php
@@ -1,0 +1,24 @@
+<?php
+namespace LangleyFoxall\Helpers\Traits;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use LangleyFoxall\Helpers\ApiResponse;
+
+trait ReturnRequestFirstError
+{
+    /**
+     * Handle a failed validation attempt.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator $validator
+     * @return void
+     *
+     * @throws \Illuminate\Http\Exceptions\HttpResponseException
+     */
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            ApiResponse::error($validator->errors()->first(), 422)->json()
+        );
+    }
+}


### PR DESCRIPTION
This trait is useful when you are only wanting the first validation error.

Expected response:
```json
{
   "status":422,
   "success":false,
   "error":"The email has already been taken.",
   "data":null,
   "meta":null
}
```

Within a service class:
```js
function create(data) {
    return new Promise((resolve, reject) => {
        window.axios
            .post('/api/users', data)
            .then(response => resolve(response.data.data.user))
            .catch(error => reject(error.response.data));
    });
}
```

Within your component:
```js
handleCreateUserFormSubmitted(submission) {
    NetworkService.user
        .create(submission.data.form)
        .then(() => this.setState({ showingModal: false }))
        .catch(response => this.setState({ errorMessage: response.error }));
}
```

Then you'll be able to use the `errorMessage` to display the error, as it is not an array.