### PR TITLE
Add Enum trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If you have never used the Composer dependency manager before, head to the [Comp
 ## Helpers
 - [`Models`](#models)
 - [`IsRelatedTo`](#isrelatedto)
+- [`Enum`](#enum)
 - [`ApiResponse`](#apiresponse)
 - [`Response`](#response)
 - [`ResponseCache`](#responsecache)
@@ -185,7 +186,7 @@ The [Enum helper](src/LangleyFoxall/Helpers/Traits/Enum.php) is a trait that pro
 
 #### Methods
 
-- [`all`](#all)
+- [`all`](#all-1)
 - [`valid`](#valid)
 
 ##### `all`

--- a/README.md
+++ b/README.md
@@ -177,6 +177,75 @@ $related = $user->isRelatedTo($post)
 | --- | ------- |
 | Parameters | [Model](https://laravel.com/docs/eloquent) or [Array](http://php.net/manual/en/language.types.array.php) |
 | Returns | [Boolean](http://php.net/manual/en/language.types.boolean.php) |
+
+---
+
+### `Enum`
+The [Enum helper](src/LangleyFoxall/Helpers/Traits/Enum.php) is a trait that provides helpers for dealing with enum classes.
+
+#### Methods
+
+- [`all`](#all)
+- [`valid`](#valid)
+
+##### `all`
+Return an array of all values.
+
+###### Example usage
+```
+class UserType
+{
+    use \LangleyFoxall\Helpers\Traits\Enum;
+
+    const ADMIN = 'admin';
+    const USER = 'user';
+}
+
+class User extends Eloquent
+{
+    public function getValidTypes()
+    {
+        return UserType::all();
+    }
+}
+```
+
+| Key | Details |
+| --- | ------- |
+| Parameters ||
+| Returns | [Array](http://php.net/manual/en/language.types.array.php) |
+
+##### `valid`
+Check if a provided value is a valid value of the enum class.
+
+###### Example usage
+```
+class UserType
+{
+    use \LangleyFoxall\Helpers\Traits\Enum;
+
+    const ADMIN = 'admin';
+    const USER = 'user';
+}
+
+class User extends Eloquent
+{
+    public function setTypeAttribute(string $type)
+    {
+        if (!UserType::valid($type)) {
+            throw new InvalidUserType;
+        }
+
+        $this->type = $type;
+    }
+}
+```
+
+| Key | Details |
+| --- | ------- |
+| Parameters | [String](http://php.net/manual/en/language.types.array.php)|
+| Returns | [Boolean](http://php.net/manual/en/language.types.boolean.php) |
+
 ---
 
 

--- a/src/LangleyFoxall/Helpers/Traits/Enum.php
+++ b/src/LangleyFoxall/Helpers/Traits/Enum.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace LangleyFoxall\Helpers\Traits;
+
+trait Enum
+{
+    /**
+     * Returns an array of all constants defined within the class.
+     *
+     * @return array
+     */
+    public static function all(): array
+    {
+        try {
+            $reflection = new \ReflectionClass(self::class);
+
+            return array_values($reflection->getConstants());
+        } catch (\ReflectionException $e) {
+            // This will never happen as the function can only ever be executed in a context where self::class is valid.
+            return [];
+        }
+    }
+
+    /**
+     * Returns a bool indicating whether or not a value is present in the class.
+     *
+     * @param string $value
+     * @return bool
+     */
+    public static function valid(string $value): bool
+    {
+        return array_search($value, self::all()) !== false;
+    }
+}

--- a/src/LangleyFoxall/Helpers/Traits/Enum.php
+++ b/src/LangleyFoxall/Helpers/Traits/Enum.php
@@ -25,6 +25,7 @@ trait Enum
      * Returns a bool indicating whether or not a value is present in the class.
      *
      * @param string $value
+     *
      * @return bool
      */
     public static function valid(string $value): bool


### PR DESCRIPTION
This trait is useful when dealing with Enum columns within the database - it can serve as the single source of truth (aside from the column definition) and saves hardcoding values in more than one place. As a result of the usage of class constants, refactoring to change, add, or remove values is simple.

The trait simply adds two static helpers: `all()` and `valid()`.

Usage involves creating a class with constants, and the use of the trait.
```php
class UserType
{
    use \LangleyFoxall\Helpers\Traits\Enum;

    const CANDIDATE = 'candidate';
    const EMPLOYER = 'employer';
}
```

It allows for a simple guard / sanity check, for example within a setter mutator on an Eloquent model.
```php
public function setTypeAttribute(string $type)
{
    if (!UserType::valid($type)) {
        throw new InvalidUserType;
    }

    $this->type = $type;
}
```

If needed, it also provides the functionality to enumerate all possible values.
```php
UserType::all()
```
