### PR TITLE
Add IdentifiedByUUID trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,23 +670,18 @@ Change your migrations to allow the use of a UUID.
 public function up()
 {
     Schema::create('demos', function (Blueprint $table) {
-        $table->uuid('uuid')->primary();
+        $table->uuid('id')->primary();
         $table->timestamps();
     });
 }
 ```
 
-Use the trait and specify your primary key name if changed.
+Use the trait.
 
 ```php
 class Demo extends Model
 {
     use IdentifiedByUUID;
-
-    /**
-     * @var string
-     */
-    protected $primaryKey = 'uuid';
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -658,13 +658,14 @@ if($cache->hasData()){
 return ApiResponse::success($data)->cache(1, $cache)->json();
 ```
 
-
 ### `IdentifiedByUUID`
 
 The `IdentifiedByUUID` trait allows you to easily use V4 UUIDs over incrementing primary keys.
 
 ###### Example Usage
+
 Change your migrations to allow the use of a UUID.
+
 ```php
 public function up()
 {
@@ -674,7 +675,9 @@ public function up()
     });
 }
 ```
+
 Use the trait and specify your primary key name if changed.
+
 ```php
 class Demo extends Model
 {

--- a/README.md
+++ b/README.md
@@ -670,7 +670,7 @@ Change your migrations to allow the use of a UUID.
 public function up()
 {
     Schema::create('demos', function (Blueprint $table) {
-        $table->string('uuid')->primary();
+        $table->uuid('uuid')->primary();
         $table->timestamps();
     });
 }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you have never used the Composer dependency manager before, head to the [Comp
 - [`ApiResponse`](#apiresponse)
 - [`Response`](#response)
 - [`ResponseCache`](#responsecache)
-
+- [`IdentifiedByUUID`](#identifiedbyuuid)
 
 ### `Models`
 The [Models helper](src/LangleyFoxall/Helpers/Models.php) offers helpful functions to do with [Eloquent Models](https://laravel.com/docs/eloquent).
@@ -657,3 +657,34 @@ if($cache->hasData()){
 
 return ApiResponse::success($data)->cache(1, $cache)->json();
 ```
+
+
+### `IdentifiedByUUID`
+
+The `IdentifiedByUUID` trait allows you to easily use V4 UUIDs over incrementing primary keys.
+
+###### Example Usage
+Change your migrations to allow the use of a UUID.
+```php
+public function up()
+{
+    Schema::create('demos', function (Blueprint $table) {
+        $table->string('uuid')->primary();
+        $table->timestamps();
+    });
+}
+```
+Use the trait and specify your primary key name if changed.
+```php
+class Demo extends Model
+{
+    use IdentifiedByUUID;
+
+    /**
+     * @var string
+     */
+    protected $primaryKey = 'uuid';
+}
+```
+
+Now when the model is saved, it will automatically be populated with a V4 UUID.

--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,17 @@
     "php": "^7.0.0",
     "illuminate/support": ">=5.0",
     "illuminate/database": ">=5.0",
-    "illuminate/http": ">=5.0"
+    "illuminate/http": ">=5.0",
+    "orchestra/testbench": "3.8.x-dev"
   },
   "autoload": {
     "psr-4": {
       "LangleyFoxall\\": "src/LangleyFoxall/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "LangleyFoxall\\": "tests/"
     }
   },
   "extra": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Helpers Laravel Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/LangleyFoxall</directory>
+        </whitelist>
+    </filter>
+    <php>
+        <env name="DB_CONNECTION" value="testing"/>
+    </php>
+</phpunit>

--- a/src/LangleyFoxall/Helpers/Traits/IdentifiedByUUID.php
+++ b/src/LangleyFoxall/Helpers/Traits/IdentifiedByUUID.php
@@ -8,7 +8,8 @@ use Illuminate\Support\Str;
  * Trait IdentifiedByUUID
  * @package LangleyFoxall\Helpers\Traits
  */
-trait IdentifiedByUUID {
+trait IdentifiedByUUID
+{
     /**
      * Boot the trait
      */

--- a/src/LangleyFoxall/Helpers/Traits/IdentifiedByUUID.php
+++ b/src/LangleyFoxall/Helpers/Traits/IdentifiedByUUID.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LangleyFoxall\Helpers\Traits;
+
+use Illuminate\Support\Str;
+
+/**
+ * Trait IdentifiedByUUID
+ * @package LangleyFoxall\Helpers\Traits
+ */
+trait IdentifiedByUUID {
+    /**
+     * Boot the trait
+     */
+    public static function bootIdentifiedByUUID()
+    {
+        static::creating(function ($model) {
+            if (!$model->getKey()) {
+                $model->{$model->getKeyName()} = (string) Str::uuid();
+            }
+        });
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIncrementing()
+    {
+        return false;
+    }
+}

--- a/src/LangleyFoxall/Helpers/Traits/IdentifiedByUUID.php
+++ b/src/LangleyFoxall/Helpers/Traits/IdentifiedByUUID.php
@@ -5,13 +5,12 @@ namespace LangleyFoxall\Helpers\Traits;
 use Illuminate\Support\Str;
 
 /**
- * Trait IdentifiedByUUID
- * @package LangleyFoxall\Helpers\Traits
+ * Trait IdentifiedByUUID.
  */
 trait IdentifiedByUUID
 {
     /**
-     * Boot the trait
+     * Boot the trait.
      */
     public static function bootIdentifiedByUUID()
     {

--- a/tests/Traits/IdentifiedByUUID/IdentifiedByUUIDTest.php
+++ b/tests/Traits/IdentifiedByUUID/IdentifiedByUUIDTest.php
@@ -7,7 +7,6 @@ use Orchestra\Testbench\TestCase;
 
 class IdentifiedByUUIDTest extends TestCase
 {
-
     /**
      * Setup the test
      */

--- a/tests/Traits/IdentifiedByUUID/IdentifiedByUUIDTest.php
+++ b/tests/Traits/IdentifiedByUUID/IdentifiedByUUIDTest.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: alex
- * Date: 28/06/2019
- * Time: 10:19
- */
+
 namespace LangleyFoxall\Traits\IdentifiedByUUID;
 
 use LangleyFoxall\Traits\IdentifiedByUUID\Models\Demo;

--- a/tests/Traits/IdentifiedByUUID/IdentifiedByUUIDTest.php
+++ b/tests/Traits/IdentifiedByUUID/IdentifiedByUUIDTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex
+ * Date: 28/06/2019
+ * Time: 10:19
+ */
+namespace LangleyFoxall\Traits\IdentifiedByUUID;
+
+use LangleyFoxall\Traits\IdentifiedByUUID\Models\Demo;
+use Orchestra\Testbench\TestCase;
+
+class IdentifiedByUUIDTest extends TestCase
+{
+
+    /**
+     * Setup the test
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loadMigrationsFrom(__DIR__ . '/Migrations');
+        $this->artisan('migrate', ['--database' => 'testing'])->run();
+    }
+
+    /**
+     * Check that saving a model correctly saves a UUID
+     * @return void
+     */
+    public function testSaveStoresUUID()
+    {
+        $demo = Demo::create(['text' => 'hello world']);
+        $this->assertRegExp('/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i', $demo->uuid);
+    }
+
+    /**
+     * Check that updating the model does not change the UUID
+     */
+    public function testUpdateDoesNotChangeUUID()
+    {
+        $demo = Demo::create(['text' => 'hello world']);
+        $uuid = $demo->uuid;
+
+        $demo->update(['text' => 'updated text']);
+
+        $this->assertTrue($demo->uuid === $uuid);
+    }
+}

--- a/tests/Traits/IdentifiedByUUID/IdentifiedByUUIDTest.php
+++ b/tests/Traits/IdentifiedByUUID/IdentifiedByUUIDTest.php
@@ -8,17 +8,17 @@ use Orchestra\Testbench\TestCase;
 class IdentifiedByUUIDTest extends TestCase
 {
     /**
-     * Setup the test
+     * Setup the test.
      */
     protected function setUp(): void
     {
         parent::setUp();
-        $this->loadMigrationsFrom(__DIR__ . '/Migrations');
+        $this->loadMigrationsFrom(__DIR__.'/Migrations');
         $this->artisan('migrate', ['--database' => 'testing'])->run();
     }
 
     /**
-     * Check that saving a model correctly saves a UUID
+     * Check that saving a model correctly saves a UUID.
      * @return void
      */
     public function testSaveStoresUUID()
@@ -28,7 +28,7 @@ class IdentifiedByUUIDTest extends TestCase
     }
 
     /**
-     * Check that updating the model does not change the UUID
+     * Check that updating the model does not change the UUID.
      */
     public function testUpdateDoesNotChangeUUID()
     {

--- a/tests/Traits/IdentifiedByUUID/IdentifiedByUUIDTest.php
+++ b/tests/Traits/IdentifiedByUUID/IdentifiedByUUIDTest.php
@@ -19,6 +19,7 @@ class IdentifiedByUUIDTest extends TestCase
 
     /**
      * Check that saving a model correctly saves a UUID.
+     *
      * @return void
      */
     public function testSaveStoresUUID()

--- a/tests/Traits/IdentifiedByUUID/Migrations/2019_06_28_121259_create_test_table.php
+++ b/tests/Traits/IdentifiedByUUID/Migrations/2019_06_28_121259_create_test_table.php
@@ -1,8 +1,8 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateTestTable extends Migration
 {

--- a/tests/Traits/IdentifiedByUUID/Migrations/2019_06_28_121259_create_test_table.php
+++ b/tests/Traits/IdentifiedByUUID/Migrations/2019_06_28_121259_create_test_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTestTable extends Migration
+{
+    /**
+     * Run the Migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('demos', function (Blueprint $table) {
+            $table->string('uuid')->primary();
+            $table->string('text');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the Migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('demos');
+    }
+}

--- a/tests/Traits/IdentifiedByUUID/Migrations/2019_06_28_121259_create_test_table.php
+++ b/tests/Traits/IdentifiedByUUID/Migrations/2019_06_28_121259_create_test_table.php
@@ -14,7 +14,7 @@ class CreateTestTable extends Migration
     public function up()
     {
         Schema::create('demos', function (Blueprint $table) {
-            $table->string('uuid')->primary();
+            $table->uuid('uuid')->primary();
             $table->string('text');
             $table->timestamps();
         });

--- a/tests/Traits/IdentifiedByUUID/Migrations/2019_06_28_121259_create_test_table.php
+++ b/tests/Traits/IdentifiedByUUID/Migrations/2019_06_28_121259_create_test_table.php
@@ -1,8 +1,8 @@
 <?php
 
+use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Database\Migrations\Migration;
 
 class CreateTestTable extends Migration
 {

--- a/tests/Traits/IdentifiedByUUID/Models/Demo.php
+++ b/tests/Traits/IdentifiedByUUID/Models/Demo.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LangleyFoxall\Traits\IdentifiedByUUID\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use LangleyFoxall\Helpers\Traits\IdentifiedByUUID;
+
+class Demo extends Model
+{
+    use IdentifiedByUUID;
+
+    /**
+     * @var string
+     */
+    protected $primaryKey = 'uuid';
+
+    /**
+     * @var array
+     */
+    protected $fillable = ['text'];
+}


### PR DESCRIPTION
It's often useful in some circumstances to have UUIDs in place of incrementing IDs, this PR adds the ability to easily use UUIDs when needed in your models.

It also includes a testing setup and the trait has tests written, this should open the door to begin writing tests for the rest of the library.