### PR TITLE
Move orchestra testbench to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,9 @@
     "php": "^7.0.0",
     "illuminate/support": ">=5.0",
     "illuminate/database": ">=5.0",
-    "illuminate/http": ">=5.0",
+    "illuminate/http": ">=5.0"
+  },
+  "require-dev": {
     "orchestra/testbench": "3.8.x-dev"
   },
   "autoload": {


### PR DESCRIPTION
Package installation is failing in certain versions of Laravel because the Orchestra Testbench is in the wrong requires section.